### PR TITLE
Behave like cp by copying over existing files

### DIFF
--- a/nr/nr.go
+++ b/nr/nr.go
@@ -209,6 +209,7 @@ func (a *Accession) HasError() bool {
 type File struct {
 	Name           string    `json:"name,omitempty"`
 	Size           string    `json:"size,omitempty"`
+	Type           string    `json:"type,omitempty"`
 	ModifiedDate   time.Time `json:"modificationDate,omitempty"`
 	Md5Hash        string    `json:"md5,omitempty"`
 	Link           string    `json:"link,omitempty"`


### PR DESCRIPTION
This also checks the disk's available space
and whether the file that's about to be copied is
larger than the available bytes. If it is, sracp
will skip that file and print out a disk full error.

Also, sracp doesn't mind if the accession folder
already exists now.