### PR TITLE
Gracefully handle a failure to resolve location

### DIFF
--- a/cmd/sracp/flags.go
+++ b/cmd/sracp/flags.go
@@ -241,7 +241,7 @@ func PopulateFlags(c *cli.Context) (ret *Flags, err error) {
 	}
 	ok := awsutil.IsLocation(loc)
 	if !ok {
-		return nil, err
+		return nil, errors.New("unable to resolve location")
 	}
 	f.Loc = loc
 


### PR DESCRIPTION
If the provided location cannot be resolved then this code would
previously return a nil error and a nil set of flags.