### PR TITLE
Correct comparison of location prefix

### DIFF
--- a/fusera.go
+++ b/fusera.go
@@ -93,13 +93,13 @@ func NewFusera(ctx context.Context, opt *Options) (*Fusera, error) {
 	if strings.HasPrefix(opt.Loc, "s3") {
 		batch = opt.AwsBatch
 	}
-	if strings.HasPrefix(opt.Loc, "gcp") {
+	if strings.HasPrefix(opt.Loc, "gs") {
 		batch = opt.GcpBatch
 	}
 	accessions, err := nr.ResolveNames(opt.ApiEndpoint, opt.Loc, opt.Ngc, batch, opt.Acc)
 	if err != nil {
 		fmt.Println(err.Error())
-		// return nil, err
+		return nil, err
 	}
 	fs := &Fusera{
 		accs:  accessions,

--- a/nr/nr.go
+++ b/nr/nr.go
@@ -88,13 +88,13 @@ func makeBatchRequest(url string, writer *multipart.Writer, body io.Reader) ([]P
 // accs: the accessions to resolve names for.
 func ResolveNames(url, loc string, ngc []byte, batch int, accs map[string]bool) (map[string]*Accession, error) {
 	if accs == nil {
-		return nil, errors.New("must provide accs to ResolveNames")
+		return nil, errors.New("must provide accessions to pass to Name Resolver API")
 	}
 	if loc == "" {
-		return nil, errors.New("must provide a location to ResolveNames")
+		return nil, errors.New("must provide a location to pass to Name Resolver API")
 	}
 	if batch < 1 {
-		return nil, errors.Errorf("must provide a batch number greater than 0: %d", batch)
+		return nil, errors.Errorf("must provide a valid batch number, gave: %d", batch)
 	}
 	if url == "" {
 		url = "https://www.ncbi.nlm.nih.gov/Traces/sdl/1/retrieve"


### PR DESCRIPTION
A brain typo caused a bug with configuring the batch
number for GCP. The location is prefixed with gs for
GCP, not gcp. Correct comparison will fix not being
able to configure GCP batch.